### PR TITLE
Ftr adding support for youtube randomizer

### DIFF
--- a/youtube/data/love/unprotected.js
+++ b/youtube/data/love/unprotected.js
@@ -2,7 +2,7 @@
 {
   const NSPACE = 'http://www.w3.org/2000/svg';
 
-  const settings = document.querySelector('.ytp-settings-button');
+  const settings = isYoutube ? document.querySelector('.ytp-settings-button') : document.querySelector('.scrobbler-div');
   if (settings) {
     const button = document.querySelector('.ytp-love-button');
     if (button) {
@@ -22,8 +22,9 @@
              'c1.4532-1.6225,3.4567-2.4549,5.4884-2.4549c1.7213,0,3.4567,0.6066,4.8535,1.8341L23.99291,15.87187');
 
       const svg = document.createElementNS(NSPACE, 'svg');
-      svg.setAttribute('height', '100%');
-      svg.setAttribute('width', '100%');
+      const widthHeight = isYoutube ? '100%' : '1em';
+      svg.setAttribute('height', widthHeight);
+      svg.setAttribute('width', widthHeight);
       svg.setAttribute('version', '1.1');
       svg.setAttribute('viewBox', '0 0 48 48');
 

--- a/youtube/data/player/protected.js
+++ b/youtube/data/player/protected.js
@@ -4,6 +4,15 @@ document.documentElement.appendChild(Object.assign(document.createElement('scrip
   textContent: `
     const isYoutube = window.location.toString().startsWith('https://www.youtube.com');
 
+    const youtubeState = {
+      UNSTARTED: -1,
+      ENDED: 0,
+      PLAYING: 1,
+      PAUSED: 2,
+      BUFFERING: 3,
+      VIDEO_CUED: 5
+    };
+
     var yttools = window.yttools || [];
 
     yttools.lastfm = {};
@@ -20,11 +29,11 @@ document.documentElement.appendChild(Object.assign(document.createElement('scrip
           state = data;
         }
 
-        if(!isYoutube && (state === 0 || state === -1)) {
+        if(!isYoutube && (state === youtubeState.ENDED || state === youtubeState.UNSTARTED)) {
           fetched = 'true';
         }  
 
-        if (fetched && state === 1) {
+        if (fetched && state === youtubeState.PLAYING) {
           window.postMessage({
             method: 'lastfm-data-fetched',
             info: player.getVideoData(),
@@ -41,8 +50,8 @@ document.documentElement.appendChild(Object.assign(document.createElement('scrip
 
       document.addEventListener('yt-page-data-fetched', e => {
         fetched = e.detail;
-        if (player.getPlayerState() === 1) {
-          onStateChange(1);
+        if (player.getPlayerState() === youtubeState.PLAYING) {
+          onStateChange(youtubeState.PLAYING);
         }
       });
 

--- a/youtube/data/scrobbler/inject.css
+++ b/youtube/data/scrobbler/inject.css
@@ -21,6 +21,10 @@
   display: none !important;
 }
 
+.ytp-svg-fill {
+  fill: #fff;
+}
+
 .scrobbler-editor {
   font-size: 12px;
   white-space: nowrap;

--- a/youtube/data/scrobbler/protected.js
+++ b/youtube/data/scrobbler/protected.js
@@ -280,6 +280,9 @@ var registerToMessages = () => {
             timer.id = window.setInterval(timer.update, 1000);
           }
           break;
+        case 'track.love': 
+        case 'track.unlove':
+          break;
         default:
           console.log('unknown method ' + data.method);
       }

--- a/youtube/data/scrobbler/protected.js
+++ b/youtube/data/scrobbler/protected.js
@@ -1,5 +1,14 @@
 'use strict';
 
+const youtubeState = {
+  UNSTARTED: -1,
+  ENDED: 0,
+  PLAYING: 1,
+  PAUSED: 2,
+  BUFFERING: 3,
+  VIDEO_CUED: 5
+};
+
 var artist;
 var track;
 var category = 'Music';
@@ -190,7 +199,6 @@ var registerToMessages = () => {
     if (data && data.method) {
       switch (data.method) {
         case 'lastfm-data-fetched':
-          console.log('lastfm-data-fetched');
           init();
           const {
             page,
@@ -260,7 +268,7 @@ var registerToMessages = () => {
           break;
         case 'lastfm-player-state':
           window.clearInterval(timer.id);
-          if (data.state === 1 && active) {
+          if (data.state === youtubeState.PLAYING && active) {
             timer.id = window.setInterval(timer.update, 1000);
           }
           break;

--- a/youtube/data/scrobbler/protected.js
+++ b/youtube/data/scrobbler/protected.js
@@ -9,6 +9,8 @@ const youtubeState = {
   VIDEO_CUED: 5
 };
 
+const isYoutube = window.location.toString().startsWith('https://www.youtube.com');
+
 var artist;
 var track;
 var category = 'Music';
@@ -73,6 +75,13 @@ var editor = {
     const parent = document.querySelector('ytd-watch #player-container') ||
       document.querySelector('ytd-player #container') || document.querySelector('#videotitle');
     editor.form = document.createElement('form');
+
+    if(!isYoutube) {
+      editor.form.addEventListener('keydown', event => {
+        event.stopPropagation(); // disable hotkeys while filling details
+      });
+    }
+    
     if (parent) {
       const aInput = Object.assign(document.createElement('input'), {
         'type': 'text',
@@ -206,7 +215,6 @@ var registerToMessages = () => {
           } = data;
           duration = data.duration;
 
-          const isYoutube = window.location.toString().startsWith('https://www.youtube.com');
           const canCheckCategory = isYoutube;
           try {
             category = page.pageData.response

--- a/youtube/manifest.json
+++ b/youtube/manifest.json
@@ -23,7 +23,8 @@
   "content_scripts": [{
     "run_at": "document_start",
     "matches": [
-      "*://*.youtube.com/*"
+      "*://*.youtube.com/*",
+      "*://youtube-playlist-randomizer.valami.info/*"
     ],
     "css": ["data/scrobbler/inject.css"],
     "js": [


### PR DESCRIPTION
This PR will add support to scrobbling from http://youtube-playlist-randomizer.valami.info/
Because of cross-site-scripting limitations a few things can't be done:
- Retrieving video category, this is why in the none-youtube flow "fetched" is "true"
- Adding the love button to the video itself
- Adding the scrobbler timer to the video itself (it appears in a similar manner, but attached differently).

In scrobbler/protected.js I changed the large if/else to a switch on the method after verifying data and data.method exist, I believe this is more readable and expandable.
