### PR TITLE
Support for YouTube tracks/chapters + title fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# last.fm-scrobbler
+
+A [Last.fm](https://last.fm) scrobbler for YouTube with support for chapters/tracks. Forked from https://github.com/rNeomy/last.fm-scrobbler - https://add0n.com/lastfm-tool.html
+
+## Install instructions
+
+### Chrome/Chromium
+
+1. Download the project code: [Download ZIP](https://github.com/nighto/last.fm-scrobbler/archive/master.zip) and extract it somewhere
+2. Open [chrome://extensions](chrome://extensions)
+3. Trigger __Developer mode__ in the upper right corner
+4. Click on __Load unpacked__ button
+5. Choose the `youtube` folder inside the extracted zip.
+6. Open a YouTube video (for instance https://www.youtube.com/watch?v=Ux_Rbgd-mOA)
+7. Authenticate with your Last.fm credentials
+8. Refresh the video page.

--- a/youtube/data/scrobbler/protected.js
+++ b/youtube/data/scrobbler/protected.js
@@ -23,6 +23,26 @@ var timer = {
   }
 };
 
+const clearString = originalTitle => originalTitle
+  .replace('VEVO','')
+  .replace(/\(?\[?Official\)?\]?/ig,'')
+  .replace(/\(?\[?HD\)?\]?/ig,'')
+  .replace(/\(?\[?Official Version\)?\]?/ig,'')
+  .replace(/\(?\[?Official Audio\)?\]?/ig,'')
+  .replace(/\(?\[?Official Video\)?\]?/ig,'')
+  .replace(/\(?\[?Official Music Video\)?\]?/ig,'')
+  .replace(/\(?\[?Official Music 4K Video\)?\]?/ig,'')
+  .replace(/\(?\[?Official 4K Music Video\)?\]?/ig,'')
+  .replace(/\(?\[?Official Music Video HD\)?\]?/ig,'')
+  .replace(/\(?\[?Official Lyric Video\)?\]?/ig,'')
+  .replace(/\(?\[?Official Promo Video\)?\]?/ig,'')
+  .replace(/\(?\[?Clipe oficial\)?\]?/ig,'')
+  .replace(/\(?\[?videoclipe oficial\)?\]?/ig,'')
+  .replace(/\(?\[?Clip Officiel\)?\]?/ig,'')
+  .replace(/\(?\[?Music Video\)?\]?/ig,'')
+  .replace(/\(?\[?Official MV\)?\]?/ig,'')
+  .trim();
+
 function check(info, period) {
   const next = resp => {
     if (resp.track) {
@@ -226,13 +246,15 @@ window.addEventListener('message', ({data}) => {
             ' // ', '-', '–', '—', ':', '|', '///', '/'
           ].filter(s => title.indexOf(s) !== -1);
           if (separators.length) {
-            const [artist, track] = title.split(separators[0]);
+            let [artist, track] = title.split(separators[0]);
+            artist = clearString(artist);
+            track = clearString(track);
             return {artist, track};
           }
           else {
             return {
-              artist: author.replace('VEVO', ''),
-              track: title
+              artist: clearString(author),
+              track: clearString(title)
             };
           }
         })(info);


### PR DESCRIPTION
In this PR I add support for YouTube chapters, so albums/compilations get scrobbled instead of the video title. Also, removes "(official video)", "[music video]" and its variations from tracks names, both for regular and timestamped videos.

Known issues / room for improvements:
- Does not support pausing / forwarding / rewarding the video, scrobbles are set as timers when the page opens relative to the timestamps.
- Supports `timestamp artist - track` format, still does not support `timestamp track`, here's a working example: https://www.youtube.com/watch?v=Ux_Rbgd-mOA
- Does not set album artist / album name

Closes #3
Closes #16 